### PR TITLE
Use godbus/dbus instead of keybase/dbus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Benehiko/go-keychain/v2
 go 1.24
 
 require (
-	github.com/keybase/dbus v0.0.0-20220506165403-5aa21ea2c23a
+	github.com/godbus/dbus/v5 v5.1.0
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/crypto v0.32.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/keybase/dbus v0.0.0-20220506165403-5aa21ea2c23a h1:K0EAzgzEQHW4Y5lxrmvPMltmlRDzlhLfGmots9EHUTI=
-github.com/keybase/dbus v0.0.0-20220506165403-5aa21ea2c23a/go.mod h1:YPNKjjE7Ubp9dTbnWvsP3HT+hYnY6TfXzubYTBeUxc8=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/secretservice/secretservice.go
+++ b/secretservice/secretservice.go
@@ -6,7 +6,7 @@ import (
 	"math/big"
 	"time"
 
-	dbus "github.com/keybase/dbus"
+	dbus "github.com/godbus/dbus/v5"
 )
 
 // SecretServiceInterface

--- a/secretservice/secretservice_test.go
+++ b/secretservice/secretservice_test.go
@@ -10,7 +10,7 @@ package secretservice
 import (
 	"testing"
 
-	dbus "github.com/keybase/dbus"
+	dbus "github.com/godbus/dbus/v5"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
Use https://github.com/godbus/dbus/ instead of https://github.com/keybase/dbus. 

- It is actively maintained
- godbus/dbus used to be called https://github.com/guelfey/go.dbus which keybase/dbus forked
- https://github.com/guelfey/go.dbus is archived